### PR TITLE
Workflow fix

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -6,10 +6,6 @@ on:
 
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   sanitize:
     runs-on: ubuntu-latest
@@ -54,7 +50,7 @@ jobs:
         env:
           API42_ID: ${{ secrets.API42_ID }}
           API42_SECRET: ${{ secrets.API42_SECRET }}
-        continue-on-error: true
+#        continue-on-error: true
         run: |
           if [[ -n $(jq -r '.[] | select(startswith("custom"))' ${HOME}/files.json) ]];
           then
@@ -63,29 +59,29 @@ jobs:
             jq -r '.[] | select(startswith("mp3")) | split("/")[1]' ${HOME}/files.json | xargs python3 check-commands.py -v --
           fi
 
-      - name: Post comment for check-commands (OK)
-        if: steps.check-commands.outcome == 'success'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'CI: HallVoice check on intra shop: OK ✅'
-            })
+#      - name: Post comment for check-commands (OK)
+#        if: steps.check-commands.outcome == 'success'
+#        uses: actions/github-script@v6
+#        with:
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          script: |
+#            github.rest.issues.createComment({
+#              issue_number: context.issue.number,
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              body: 'CI: HallVoice check on intra shop: OK ✅'
+#            })
 
-      - name: Post comment for check-commands (KO)
-        if: steps.check-commands.outcome != 'success'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'CI: HallVoice check on intra shop: KO ❌'
-            })
-            core.setFailed('HallVoice check on intra shop KO')
+#      - name: Post comment for check-commands (KO)
+#        if: steps.check-commands.outcome != 'success'
+#        uses: actions/github-script@v6
+#        with:
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          script: |
+#            github.rest.issues.createComment({
+#              issue_number: context.issue.number,
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              body: 'CI: HallVoice check on intra shop: KO ❌'
+#            })
+#            core.setFailed('HallVoice check on intra shop KO')


### PR DESCRIPTION
- Remove post of comments that cause workflows to crash even if all is good
- Remove `continue-on-error: true` in `check-commands` to stop workflow when check is KO